### PR TITLE
typo: cette propriété est la réflexivité, pas la symétrie

### DIFF
--- a/chapitres/1_calcul_des_propositions.tex
+++ b/chapitres/1_calcul_des_propositions.tex
@@ -507,7 +507,7 @@ De nombreuses règles de déduction sont équivalentes à $({\neg}{\neg}E)$. Par
 \infer[(\text{RAA})]{A}{\infer*{\bot}{[\neg A]}}
 \end{align*}
 
-De ce fait, en logique intuitionniste, il n'est pas possible de faire usage du principe du \textit{tiers exclu} (TDN, pour \textit{tertium non datur}) ou du raisonnement par l'absurde (RAA, pour \textit{reductio ad absurdum}). À noter que l'absence règle RAA en logique intuitionniste n'empêche pas de prouver une négation par \og \textit{réfutation} \fg{}:
+De ce fait, en logique intuitionniste, il n'est pas possible de faire usage du principe du \textit{tiers exclu} (TND, pour \textit{tertium non datur}) ou du raisonnement par l'absurde (RAA, pour \textit{reductio ad absurdum}). À noter que l'absence règle RAA en logique intuitionniste n'empêche pas de prouver une négation par \og \textit{réfutation} \fg{}:
 
 \[
 \infer[(\text{Réfutation})]{\neg A}{\infer*{\bot}{[A]}}

--- a/chapitres/2_calcul_des_predicats.tex
+++ b/chapitres/2_calcul_des_predicats.tex
@@ -54,7 +54,7 @@ Le prédicat jouit de plusieurs règles d'inférence.
 \begin{enumerate}
 \item Pour toute variable $x$:
 \[
-\infer[({=}\text{-sym})]{x = x}{}
+\infer[({=}\text{-réfl})]{x = x}{}
 \]
 \item Pour toutes variables $x_1$ \dots $x_n$, et $y_1$ \dots $y_n$, et fonction $f$ d'arité $n$:
 \[


### PR DESCRIPTION
Petit _typo_ décelé en lisant les notes des premiers cours: "x = x" est la **réflexivité** de l'égalité, et non pas la _symétrie_